### PR TITLE
Update novels.js item url

### DIFF
--- a/lib/v2/pixiv/novels.js
+++ b/lib/v2/pixiv/novels.js
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
     const items = Object.values(data.body.works).map((item) => ({
         title: item.seriesTitle || item.title,
         description: item.description || item.title,
-        link: `${baseUrl}/novel/series/${item.id}`,
+        link: `${baseUrl}/novel/show.php?id=${item.id}`,
         author: item.userName,
         pubDate: parseDate(item.createDate),
         updated: parseDate(item.updateDate),


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None, or this PR is also an issue: the router can fetch novel posts from a pixiv user correctly, but parser gives invalid source urls. 

## Example for the Proposed Route(s) / 路由地址示例

NOROUTE

## New RSS Route Checklist / 新 RSS 路由检查表
  
NOROUTE


## Note / 说明

The link before this commit itself is a valid format, but only for novel series (as the url implies). In my experience for a couple of weeks, all updates were pushed from individual novel posts, not novel series. Moreover, I believe pixiv's webUI never list series as new items, only individual posts. Therefore I think this change should be fine, but I'm quite new to following pixiv via rsshub. 